### PR TITLE
Add optional repository root to FileCache constructor

### DIFF
--- a/Acrobit.AcroFS/Caching/CacheExtension.cs
+++ b/Acrobit.AcroFS/Caching/CacheExtension.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using Acrobit.AcroFS.Caching;
+
+using Microsoft.Extensions.Internal;
 
 using System;
 using System.Threading.Tasks;
-using global::Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Internal;
-using Acrobit.AcroFS.Caching;
 
 namespace Microsoft.Extensions.Caching.Memory
 {
@@ -72,7 +69,7 @@ namespace Microsoft.Extensions.Caching.Memory
         public static TItem Set<TItem>(this FileCache cache, object key, TItem value, TimeSpan expirationInterval, bool isSlidingExpiration = false)
         {
             var entry = cache.CreateEntry(key);
-            if(isSlidingExpiration)
+            if (isSlidingExpiration)
                 entry.SlidingExpiration = expirationInterval;
             else entry.AbsoluteExpirationRelativeToNow = expirationInterval;
             entry.Value = value;
@@ -138,7 +135,7 @@ namespace Microsoft.Extensions.Caching.Memory
                 var entry = cache.CreateEntry(key);
                 result = await factory(entry);
                 entry.SetValue(result);
-                
+
                 // need to manually call dispose instead of having a using
                 // in case the factory passed in throws, in which case we
                 // do not want to add the entry to the cache
@@ -171,19 +168,14 @@ namespace Microsoft.Extensions.Caching.Memory
 
         }
 
-        public static FileCache Persistent(this IMemoryCache cache)
+        public static FileCache Persistent(this IMemoryCache cache, string repositoryRoot = null)
         {
-            return new FileCache(new SystemClock(), cache);
+            return new FileCache(new SystemClock(), cache, repositoryRoot);
         }
 
-        public static FileCache Persistent(this IMemoryCache cache, ISystemClock clock)
+        public static FileCache Persistent(this IMemoryCache cache, ISystemClock clock, string repositoryRoot = null)
         {
-            return new FileCache(clock, cache);
+            return new FileCache(clock, cache, repositoryRoot);
         }
-
-
-
-
-
     }
 }

--- a/Acrobit.AcroFS/Caching/FileCache.cs
+++ b/Acrobit.AcroFS/Caching/FileCache.cs
@@ -1,24 +1,18 @@
 ﻿using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Internal;
-using Microsoft.Extensions.Options;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
 
 namespace Acrobit.AcroFS.Caching
 {
-
     public class FileCache //: IMemoryCache
     {
         private readonly ISystemClock _systemClock;
         private readonly IMemoryCache _memCache;
         private readonly FileStore _fileStore;
         private readonly string cacheCluster = "__cache__";
-        public FileCache(ISystemClock systemClock, IMemoryCache memCache)
+
+        public FileCache(ISystemClock systemClock, IMemoryCache memCache, string repositoryRoot = null)
         {   
-            _fileStore =  FileStore.CreateStore();
+            _fileStore =  FileStore.CreateStore(repositoryRoot);
             _systemClock = systemClock;
             _memCache = memCache;
         }
@@ -67,6 +61,7 @@ namespace Acrobit.AcroFS.Caching
             _fileStore.StoreByKey(entry.Key, (T)entry.Value, cacheCluster);
 
         }
+
         public bool TryGetValue<T>(object key, out T value) 
         {
             if (!_memCache.TryGetValue(key, out value)) // check inside memory
@@ -99,11 +94,10 @@ namespace Acrobit.AcroFS.Caching
                     return !expired;
                 }
             }
-            else return true;
+            else 
+                return true;
 
             return false;
-
-
         }
     }
 }


### PR DESCRIPTION
You may not always want the default repository root folder for your cache.  Now you have the option to change the root folder when using the Persistent methods.  That allows you to do this:
```csharp
cache.Persistent(@"d:\somefolder");
```