### PR TITLE
Add async versions for most get/set cache and store methods

### DIFF
--- a/AcroFS.Tests/FileCacheTests.cs
+++ b/AcroFS.Tests/FileCacheTests.cs
@@ -1,21 +1,16 @@
-﻿using System.IO;
-using Moq;
-using Xunit;
-using Acrobit.AcroFS.Tests.Helpers;
+﻿using Acrobit.AcroFS.Tests.Helpers;
+
 using AcroFS.Tests;
-using Acrobit.AcroFS.Caching;
-using Microsoft.Extensions.Internal;
-using System;
+
 using Microsoft.Extensions.Caching.Memory;
-using System.Threading.Tasks;
+using Microsoft.Extensions.Internal;
+
+using System;
+
+using Xunit;
 
 namespace Acrobit.AcroFS.Tests
-{   
-    public class MyModel
-    {
-        public string Name{ get; set; }
-        public int Age { get; set; }
-    }
+{
     public class FileCacheTests
     {
         public FileCacheTests()
@@ -27,7 +22,6 @@ namespace Acrobit.AcroFS.Tests
         {
             return new MemoryCache(new MemoryCacheOptions { Clock = clock });
         }
-
 
         [Fact]
         public void FileCacheReloadsCacheDataAfterRestart()
@@ -60,9 +54,7 @@ namespace Acrobit.AcroFS.Tests
             found = cache.TryGetValue(key, out result);
             Assert.True(found);
             Assert.Equal(value, result);
-
         }
-
 
         [Fact]
         public void ExpirationAfterRestartDoesntAddEntry()
@@ -98,50 +90,6 @@ namespace Acrobit.AcroFS.Tests
             found = cache.TryGetValue(key, out result);
             Assert.False(found);
             Assert.NotEqual(value, result);
-
-
-
         }
-
-        //[Fact]
-        //public async Task SlidingExpirationAfterRestartAddsEntryInMemory()
-        //{
-        //    var clock = new TestClock();
-        //    var cache = CreateCache(clock)
-        //        .Persistent(clock);
-
-        //    var key = "myKey";
-        //    var value = "myValue";
-
-        //    var result = cache.Set(key, value, TimeSpan.FromMinutes(1), isSlidingExpiration: true);
-        //    Assert.Equal(value, result);
-
-        //    var found = cache.TryGetValue(key, out result);
-        //    Assert.True(found);
-        //    Assert.Equal(value, result);
-
-        //    // restart by new memory cache instantiation
-        //    var memCache = CreateCache(clock);
-
-        //    found = memCache.TryGetValue(key, out result);
-        //    Assert.False(found);
-        //    Assert.Null(result);
-
-        //    // try with persistant cache
-        //    cache = CreateCache(clock)
-        //        .Persistent(clock);
-
-        //    found = cache.TryGetValue(key, out result);
-        //    Assert.True(found);
-        //    Assert.Equal(value, result);
-
-        //}
-
-
-
-
-
-
-
     }
 }

--- a/AcroFS.Tests/FileStoreTests.cs
+++ b/AcroFS.Tests/FileStoreTests.cs
@@ -1,13 +1,13 @@
-﻿using System.IO;
-using Moq;
-using Xunit;
-using Acrobit.AcroFS.Tests.Helpers;
+﻿using Acrobit.AcroFS.Tests.Helpers;
+
 using AcroFS.Tests;
+
+using System.IO;
+
+using Xunit;
 
 namespace Acrobit.AcroFS.Tests
 {
-
-
     public class FileStoreTests
     {
         readonly string StoragePath1 = "";
@@ -46,11 +46,10 @@ namespace Acrobit.AcroFS.Tests
 
             Assert.Equal("the content", _store.LoadText(docId));
         }
+
         [Fact]
         public void AttachmentTest()
         {
-            
-
             var _store = FileStore.CreateStore(StoragePath1);
 
             // create doc
@@ -68,8 +67,8 @@ namespace Acrobit.AcroFS.Tests
             var contents = _store.LoadTextAttachments(docId);
 
             Assert.Equal(2, contents.Count);
-
         }
+
         [Fact]
         public void MultipleStoreTest()
         {
@@ -81,7 +80,6 @@ namespace Acrobit.AcroFS.Tests
 
             Assert.Equal("content 1", _storeOne.LoadText(docId1) );
             Assert.Equal("content 2", _storeTwo.LoadText(docId2) );
-
         }
 
         [Fact]
@@ -101,8 +99,8 @@ namespace Acrobit.AcroFS.Tests
 
             Assert.Equal(2, docId1);
             Assert.Equal(2, docId2);
-
         }
+
         [Fact]
         public void StreamTest()
         {
@@ -117,7 +115,6 @@ namespace Acrobit.AcroFS.Tests
             }
 
             Assert.Equal("the content", _store.LoadText(docId) );
-
         }
 
         [Fact]
@@ -133,9 +130,9 @@ namespace Acrobit.AcroFS.Tests
             var stream = _store.Load(docId);
             var text = _store.LoadText(docId, options: LoadOptions.Decompress);
 
-            Assert.True(stream.Length < text.Length);
-
+            Assert.True(stream!.Length < text!.Length);
         }
+
         [Fact]
         public void ObjectStoreTests()
         {
@@ -152,13 +149,9 @@ namespace Acrobit.AcroFS.Tests
             
             var loadedData = _store.Load<SimpleModel>(docId);
 
-            Assert.Equal(loadedData.Email, data.Email);
-            Assert.Equal(loadedData.Name, data.Name);
-
+            Assert.Equal(loadedData!.Email, data.Email);
+            Assert.Equal(loadedData!.Name, data.Name);
         }
-
-
-        
 
         [Fact]
         public void SubStorageTests()
@@ -167,18 +160,15 @@ namespace Acrobit.AcroFS.Tests
 
             //  creating news docs
             long newsId1 = _store.StoreText("news content 1", "news");
-            long newsId2 = _store.StoreText("news content 2", "news");
+            _ = _store.StoreText("news content 2", "news");
 
             //  creating articles docs
-            long articleId1 = _store.StoreText("article content 1", "article");
+            _ = _store.StoreText("article content 1", "article");
             long articleId2 = _store.StoreText("article content 2", "article");
 
             //  loading
             Assert.Equal("news content 1", _store.LoadText(newsId1, "news"));
             Assert.Equal("article content 2", _store.LoadText(articleId2, "article"));
-
-
-
         }
 
         [Fact]
@@ -189,12 +179,10 @@ namespace Acrobit.AcroFS.Tests
             //  creating news docs
             long newsId1 = _store.StoreText("economic news content 1", "news/economic");
             long newsId2 = _store.StoreText("health news content 1", "news/health");
-
  
             //  loading
             Assert.Equal("economic news content 1", _store.LoadText(newsId1, "news/economic"));
             Assert.Equal("health news content 1", _store.LoadText(newsId2, "news/health"));
-
         }
 
         [Fact]
@@ -209,7 +197,6 @@ namespace Acrobit.AcroFS.Tests
                 Email = "ghominejad@gmail.com"
             };
 
-
             var key = "SimpleModel.json";
 
             // store by a key
@@ -218,9 +205,8 @@ namespace Acrobit.AcroFS.Tests
             // load by a key
             var loadedData = _store.Load<SimpleModel>(key);
 
-            Assert.Equal(loadedData.Email, data.Email);
-            Assert.Equal(loadedData.Name, data.Name);
-
+            Assert.Equal(loadedData!.Email, data.Email);
+            Assert.Equal(loadedData!.Name, data.Name);
         }
 
         [Fact]
@@ -235,7 +221,6 @@ namespace Acrobit.AcroFS.Tests
                 Email = "ghominejad@gmail.com"
             };
 
-
             var key = "SimpleModel.json";
 
             // store by a key
@@ -244,11 +229,8 @@ namespace Acrobit.AcroFS.Tests
             // load by a key
             var loadedData = _store.Load<SimpleModel>(key);
 
-            Assert.Equal(loadedData.Email, data.Email);
-            Assert.Equal(loadedData.Name, data.Name);
-
+            Assert.Equal(loadedData!.Email, data.Email);
+            Assert.Equal(loadedData!.Name, data.Name);
         }
-
-
     }
 }

--- a/AcroFS.Tests/SimpleModel.cs
+++ b/AcroFS.Tests/SimpleModel.cs
@@ -1,15 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AcroFS.Tests
+﻿namespace AcroFS.Tests
 {
     public class SimpleModel
     {
-        public string Name {  get; set; }
-        public string Email { get; set; }
+        public string? Name {  get; set; }
 
+        public string? Email { get; set; }
     }
 }

--- a/Acrobit.AcroFS/Acrobit.AcroFS.csproj
+++ b/Acrobit.AcroFS/Acrobit.AcroFS.csproj
@@ -1,30 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <RootNamespace>Acrobit.AcroFS</RootNamespace>
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-  <PropertyGroup>
-    <PackageId>Acrobit.AcroFS</PackageId>
-    <Version>2.1.16</Version>
-    <Authors>ghominejad</Authors>
-    <Company>Gita</Company>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Remove="Helpers\**" />
-    <EmbeddedResource Remove="Helpers\**" />
-    <None Remove="Helpers\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
+	<PropertyGroup>
+		<TargetFramework>netstandard2.1</TargetFramework>
+		<RootNamespace>Acrobit.AcroFS</RootNamespace>
+		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<PropertyGroup>
+		<PackageId>Acrobit.AcroFS</PackageId>
+		<Version>2.1.16</Version>
+		<Authors>ghominejad</Authors>
+		<Company>Gita</Company>
+	</PropertyGroup>
+	<PropertyGroup>
+		<LangVersion>11.0</LangVersion>
+	</PropertyGroup>
+	<ItemGroup>
+		<Compile Remove="Helpers\**" />
+		<EmbeddedResource Remove="Helpers\**" />
+		<None Remove="Helpers\**" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
 
-    <!--<PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+		<!--<PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />-->
-  </ItemGroup>
+	</ItemGroup>
 
 </Project>
 

--- a/Acrobit.AcroFS/Caching/CacheExtension.cs
+++ b/Acrobit.AcroFS/Caching/CacheExtension.cs
@@ -46,6 +46,19 @@ namespace Microsoft.Extensions.Caching.Memory
                 cache.Persist<TItem>(entry);
             }
 
+            return value;
+        }
+
+        public static async Task<TItem> SetAsync<TItem>(this FileCache cache, object key, TItem value)
+        {
+            var entry = cache.CreateEntry(key);
+            entry.Value = value;
+            entry.Dispose();
+
+            if (cache.Get(key) != null)
+            {
+                await cache.PersistAsync<TItem>(entry);
+            }
 
             return value;
         }
@@ -61,6 +74,22 @@ namespace Microsoft.Extensions.Caching.Memory
             if (cache.Get(key) != null)
             {
                 cache.Persist<TItem>(entry);
+            }
+
+            return value;
+        }
+
+        public static async Task<TItem> SetAsync<TItem>(this FileCache cache, object key, TItem value, DateTimeOffset absoluteExpiration)
+        {
+            var entry = cache.CreateEntry(key);
+            entry.AbsoluteExpiration = absoluteExpiration;
+            entry.Value = value;
+
+            entry.Dispose();
+
+            if (cache.Get(key) != null)
+            {
+                await cache.PersistAsync<TItem>(entry);
             }
 
             return value;
@@ -84,6 +113,23 @@ namespace Microsoft.Extensions.Caching.Memory
             return value;
         }
 
+        public static async Task<TItem> SetAsync<TItem>(this FileCache cache, object key, TItem value, TimeSpan expirationInterval, bool isSlidingExpiration = false)
+        {
+            var entry = cache.CreateEntry(key);
+            if (isSlidingExpiration)
+                entry.SlidingExpiration = expirationInterval;
+            else entry.AbsoluteExpirationRelativeToNow = expirationInterval;
+            entry.Value = value;
+
+            entry.Dispose();
+
+            if (cache.Get(key) != null)
+            {
+                await cache.PersistAsync<TItem>(entry);
+            }
+
+            return value;
+        }
 
         public static TItem Set<TItem>(this FileCache cache, object key, TItem value, MemoryCacheEntryOptions options)
         {
@@ -102,7 +148,25 @@ namespace Microsoft.Extensions.Caching.Memory
                 }
             }
 
+            return value;
+        }
 
+        public static async Task<TItem> SetAsync<TItem>(this FileCache cache, object key, TItem value, MemoryCacheEntryOptions options)
+        {
+            using (var entry = cache.CreateEntry(key))
+            {
+                if (options != null)
+                {
+                    entry.SetOptions(options);
+                }
+
+                entry.Value = value;
+
+                if (cache.Get(key) != null)
+                {
+                    await cache.PersistAsync<TItem>(entry);
+                }
+            }
 
             return value;
         }
@@ -143,7 +207,7 @@ namespace Microsoft.Extensions.Caching.Memory
 
                 if (cache.Get(key) != null)
                 {
-                    cache.Persist<TItem>(entry);
+                    await cache.PersistAsync<TItem>(entry);
                 }
             }
 

--- a/Acrobit.AcroFS/Caching/CacheExtension.cs
+++ b/Acrobit.AcroFS/Caching/CacheExtension.cs
@@ -15,25 +15,10 @@ namespace Microsoft.Extensions.Caching.Memory
             return value;
         }
 
-        public static TItem Get<TItem>(this FileCache cache, object key)
+        public static TItem? Get<TItem>(this FileCache cache, object key)
         {
-            return (TItem)(cache.Get(key) ?? default(TItem));
+            return (TItem?)(cache.Get(key) ?? default(TItem));
         }
-
-        //public static bool TryGetValue<TItem>(this FsCache cache, object key, out TItem value)
-        //{
-        //    if (cache.TryGetValue(key, out object result))
-        //    {
-        //        if (result is TItem item)
-        //        {
-        //            value = item;
-        //            return true;
-        //        }
-        //    }
-
-        //    value = default;
-        //    return false;
-        //}
 
         public static TItem Set<TItem>(this FileCache cache, object key, TItem value)
         {
@@ -171,13 +156,14 @@ namespace Microsoft.Extensions.Caching.Memory
             return value;
         }
 
-        public static TItem GetOrCreate<TItem>(this FileCache cache, object key, Func<ICacheEntry, TItem> factory)
+        public static TItem? GetOrCreate<TItem>(this FileCache cache, object key, Func<ICacheEntry, TItem> factory)
         {
-            if (!cache.TryGetValue(key, out object result))
+            if (!cache.TryGetValue(key, out object? result))
             {
                 var entry = cache.CreateEntry(key);
                 result = factory(entry);
                 entry.SetValue(result);
+
                 // need to manually call dispose instead of having a using
                 // in case the factory passed in throws, in which case we
                 // do not want to add the entry to the cache
@@ -189,7 +175,7 @@ namespace Microsoft.Extensions.Caching.Memory
                 }
             }
 
-            return (TItem)result;
+            return (TItem?)result;
         }
 
         public static async Task<TItem> GetOrCreateAsync<TItem>(this FileCache cache, object key, Func<ICacheEntry, Task<TItem>> factory)
@@ -232,12 +218,12 @@ namespace Microsoft.Extensions.Caching.Memory
 
         }
 
-        public static FileCache Persistent(this IMemoryCache cache, string repositoryRoot = null)
+        public static FileCache Persistent(this IMemoryCache cache, string? repositoryRoot = null)
         {
             return new FileCache(new SystemClock(), cache, repositoryRoot);
         }
 
-        public static FileCache Persistent(this IMemoryCache cache, ISystemClock clock, string repositoryRoot = null)
+        public static FileCache Persistent(this IMemoryCache cache, ISystemClock clock, string? repositoryRoot = null)
         {
             return new FileCache(clock, cache, repositoryRoot);
         }

--- a/Acrobit.AcroFS/Caching/FileCache.cs
+++ b/Acrobit.AcroFS/Caching/FileCache.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Internal;
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 namespace Acrobit.AcroFS.Caching
@@ -81,7 +82,7 @@ namespace Acrobit.AcroFS.Caching
             await _fileStore.StoreByKeyAsync(entry.Key, (T)entry.Value, cacheCluster);
         }
 
-        public bool TryGetValue<T>(object key, out T value)
+        public bool TryGetValue<T>(object key, [NotNullWhen(true)] out T value)
         {
             if (!_memCache.TryGetValue(key, out value)) // check inside memory
             {
@@ -118,7 +119,7 @@ namespace Acrobit.AcroFS.Caching
             return false;
         }
 
-        public async Task<(bool, T)> TryGetValueAsync<T>(object key)
+        public async Task<(bool, T?)> TryGetValueAsync<T>(object key) where T : class
         {
             if (!_memCache.TryGetValue(key, out T value)) // check inside memory
             {

--- a/Acrobit.AcroFS/Caching/FileCache.cs
+++ b/Acrobit.AcroFS/Caching/FileCache.cs
@@ -13,7 +13,7 @@ namespace Acrobit.AcroFS.Caching
         private readonly FileStore _fileStore;
         private readonly string cacheCluster = "__cache__";
 
-        public FileCache(ISystemClock systemClock, IMemoryCache memCache, string repositoryRoot = null)
+        public FileCache(ISystemClock systemClock, IMemoryCache memCache, string? repositoryRoot = null)
         {
             _fileStore = FileStore.CreateStore(repositoryRoot);
             _systemClock = systemClock;

--- a/Acrobit.AcroFS/Caching/FileCache.cs
+++ b/Acrobit.AcroFS/Caching/FileCache.cs
@@ -137,7 +137,7 @@ namespace Acrobit.AcroFS.Caching
                 if (_fileStore.Exists(key, cacheCluster)) // check inside disk
                 {
                     // check expiration
-                    var cacheEntryOptions = _fileStore.LoadAttachment<FileCacheEntryOptions>(key, "FsCacheEntryOptions", cacheCluster);
+                    var cacheEntryOptions = await _fileStore.LoadAttachmentAsync<FileCacheEntryOptions>(key, "FsCacheEntryOptions", cacheCluster);
                     var expired = false;
                     if (cacheEntryOptions != null)
                     {

--- a/Acrobit.AcroFS/Caching/FileCache.cs
+++ b/Acrobit.AcroFS/Caching/FileCache.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Internal;
 
+using System.Threading.Tasks;
+
 namespace Acrobit.AcroFS.Caching
 {
     public class FileCache //: IMemoryCache
@@ -11,12 +13,12 @@ namespace Acrobit.AcroFS.Caching
         private readonly string cacheCluster = "__cache__";
 
         public FileCache(ISystemClock systemClock, IMemoryCache memCache, string repositoryRoot = null)
-        {   
-            _fileStore =  FileStore.CreateStore(repositoryRoot);
+        {
+            _fileStore = FileStore.CreateStore(repositoryRoot);
             _systemClock = systemClock;
             _memCache = memCache;
         }
-        
+
         public ICacheEntry CreateEntry(object key)
         {
             return _memCache.CreateEntry(key);
@@ -43,7 +45,6 @@ namespace Acrobit.AcroFS.Caching
 
         public void Persist<T>(ICacheEntry entry)
         {
-
             if (entry.HasExpiration())
             {
                 var options = new FileCacheEntryOptions
@@ -59,10 +60,28 @@ namespace Acrobit.AcroFS.Caching
             }
 
             _fileStore.StoreByKey(entry.Key, (T)entry.Value, cacheCluster);
-
         }
 
-        public bool TryGetValue<T>(object key, out T value) 
+        public async Task PersistAsync<T>(ICacheEntry entry)
+        {
+            if (entry.HasExpiration())
+            {
+                var options = new FileCacheEntryOptions
+                {
+                    AbsoluteExpiration = entry.AbsoluteExpiration,
+                    SlidingExpiration = entry.SlidingExpiration,
+                    AbsoluteExpirationRelativeToNow = entry.AbsoluteExpirationRelativeToNow,
+                    Size = entry.Size,
+                    Priority = entry.Priority
+                };
+
+                await _fileStore.AttachAsync(entry.Key, "FsCacheEntryOptions", options, cacheCluster);
+            }
+
+            await _fileStore.StoreByKeyAsync(entry.Key, (T)entry.Value, cacheCluster);
+        }
+
+        public bool TryGetValue<T>(object key, out T value)
         {
             if (!_memCache.TryGetValue(key, out value)) // check inside memory
             {
@@ -73,7 +92,6 @@ namespace Acrobit.AcroFS.Caching
                     var expired = false;
                     if (cacheEntryOptions != null)
                         expired = cacheEntryOptions.CheckExpired(_systemClock.UtcNow);
-
 
                     if (!expired)
                     {
@@ -94,10 +112,52 @@ namespace Acrobit.AcroFS.Caching
                     return !expired;
                 }
             }
-            else 
+            else
                 return true;
 
             return false;
+        }
+
+        public async Task<(bool, T)> TryGetValueAsync<T>(object key)
+        {
+            if (!_memCache.TryGetValue(key, out T value)) // check inside memory
+            {
+                if (_fileStore.Exists(key, cacheCluster)) // check inside disk
+                {
+                    // check expiration
+                    var cacheEntryOptions = _fileStore.LoadAttachment<FileCacheEntryOptions>(key, "FsCacheEntryOptions", cacheCluster);
+                    var expired = false;
+                    if (cacheEntryOptions != null)
+                        expired = cacheEntryOptions.CheckExpired(_systemClock.UtcNow);
+
+                    if (!expired)
+                    {
+                        value = await _fileStore.LoadAsync<T>(key, cacheCluster); // load from disk
+
+                        // create cache in-memory
+                        var entry = CreateEntry(key);
+                        if (cacheEntryOptions != null)
+                        {
+                            entry.SetOptions(cacheEntryOptions.ToMemoryOptions());
+                        }
+
+                        entry.SetValue(value);
+
+                        // need to manually call dispose instead of having a using
+                        // in case the factory passed in throws, in which case we
+                        // do not want to add the entry to the cache
+                        entry.Dispose();
+                    }
+
+                    return (!expired, value);
+                }
+            }
+            else
+            {
+                return (true, value);
+            }
+
+            return (false, default(T));
         }
     }
 }

--- a/Acrobit.AcroFS/Core.cs
+++ b/Acrobit.AcroFS/Core.cs
@@ -5,298 +5,341 @@ using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading.Tasks;
 
 // Gita FileSystem Storage
 namespace Acrobit.AcroFS
 {
-	public class Core
-	{
-		
-		public StoreConfig _config;
+    public class Core
+    {
+
+        public StoreConfig _config;
         string _repositoryRoot;
 
-        public string RepositoryRoot{
-			get{
-				
-				return _repositoryRoot;
-			}		
-		}
-
-		public static string GetDefaultRepositoryPath()
+        public string RepositoryRoot
         {
-			var defaultPath = Path.Combine(
-				AppDomain.CurrentDomain.BaseDirectory,
-				"Data",
-				"default-store/"
-				);
+            get
+            {
 
-
-
-
-			return defaultPath;
-
-		}
-
-		//public Core(StoreConfig config=null)
-		//{
-		//	var repositoryRoot = GetDefaultRepositoryPath();
-		//	if (!Directory.Exists(repositoryRoot))
-		//		Directory.CreateDirectory(repositoryRoot);
-
-		//	_repositoryRoot = repositoryRoot;
-  //          _config = config;
-  //      }
-
-		public Core(string repositoryRoot=null, StoreConfig config=null)
-        {
-			_config = config ?? new StoreConfig
-			{
-				UseSimplePath = false,
-				
-			};
-
-			Root(repositoryRoot);
-			
+                return _repositoryRoot;
+            }
         }
 
-		public string GenerateHashedPath(object key)
+        public static string GetDefaultRepositoryPath()
         {
-			if (key.GetType() == typeof(string))
-				return GenerateHashedPath((string)key);
-			if (key.GetType() == typeof(int))
-				return GenerateHashedPath((int)key);
-			else return GenerateHashedPath((long)key);
-
-		}
+            var defaultPath = Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory,
+                "Data",
+                "default-store/"
+                );
 
 
-		public string GenerateHashedPath(long val)
-		{
-			if(val==0)
-				return "";
-			
-			string hex = val.ToString("X");
-			hex=hex.PadLeft(10, '0');
-
-			string hashed="";
-			for(int i=0; i<hex.Length; i+=2 )
-			{
-				hashed += "$"+hex.Substring(i,2);
-				
-				if(i+2<hex.Length)
-					hashed+="/";
-			}
-			
-			return hashed;
-		}
-		public string GenerateHashedPath(string val)
-		{
-			if (string.IsNullOrEmpty(val))
-				return "";
-
-			if (_config != null && _config.UseSimplePath)
-				return val;
-
-			val = val.PadLeft(10, '0');
-			
-			if(val.Length%2 == 1) val = "_" + val;
-			
-			string hashed = "";
-			for (int i = 0; i < val.Length; i += 2)
-			{
-				hashed += "$" + val.Substring(i, 2);
-
-				if (i + 2 < val.Length)
-					hashed += "/";
-			}
-
-			return hashed;
-		}
 
 
-		public ConcurrentDictionary<long, ConcurrentDictionary<string, StoreId>> dicClusters = 
-			new ConcurrentDictionary<long, ConcurrentDictionary<string, StoreId>>();
-	
-		public string GetHashedPath(object key, long clusterId, string clusterPath)
-		{
-			
-			string left=GenerateHashedPath(clusterId);
-			
-			string right=GenerateHashedPath(key);		
-			
-			string path = RepositoryRoot;
-			
-			if(left.Length>0)
-				 path+= left+"/";
-			
-			if(clusterPath.Length>0)
-				 path+= clusterPath+"/";
-			
-			if(right.Length>0)
-				path+=right;
-			
-			return path;
-			
-		}
-		
+            return defaultPath;
 
-		public string GetHashedPath(long id,  string clusterPath)
+        }
+
+        //public Core(StoreConfig config=null)
+        //{
+        //	var repositoryRoot = GetDefaultRepositoryPath();
+        //	if (!Directory.Exists(repositoryRoot))
+        //		Directory.CreateDirectory(repositoryRoot);
+
+        //	_repositoryRoot = repositoryRoot;
+        //          _config = config;
+        //      }
+
+        public Core(string repositoryRoot = null, StoreConfig config = null)
+        {
+            _config = config ?? new StoreConfig
+            {
+                UseSimplePath = false,
+
+            };
+
+            Root(repositoryRoot);
+
+        }
+
+        public string GenerateHashedPath(object key)
+        {
+            if (key.GetType() == typeof(string))
+                return GenerateHashedPath((string)key);
+            if (key.GetType() == typeof(int))
+                return GenerateHashedPath((int)key);
+            else return GenerateHashedPath((long)key);
+
+        }
+
+
+        public string GenerateHashedPath(long val)
+        {
+            if (val == 0)
+                return "";
+
+            string hex = val.ToString("X");
+            hex = hex.PadLeft(10, '0');
+
+            string hashed = "";
+            for (int i = 0; i < hex.Length; i += 2)
+            {
+                hashed += "$" + hex.Substring(i, 2);
+
+                if (i + 2 < hex.Length)
+                    hashed += "/";
+            }
+
+            return hashed;
+        }
+        public string GenerateHashedPath(string val)
+        {
+            if (string.IsNullOrEmpty(val))
+                return "";
+
+            if (_config != null && _config.UseSimplePath)
+                return val;
+
+            val = val.PadLeft(10, '0');
+
+            if (val.Length % 2 == 1) val = "_" + val;
+
+            string hashed = "";
+            for (int i = 0; i < val.Length; i += 2)
+            {
+                hashed += "$" + val.Substring(i, 2);
+
+                if (i + 2 < val.Length)
+                    hashed += "/";
+            }
+
+            return hashed;
+        }
+
+
+        public ConcurrentDictionary<long, ConcurrentDictionary<string, StoreId>> dicClusters =
+            new ConcurrentDictionary<long, ConcurrentDictionary<string, StoreId>>();
+
+        public string GetHashedPath(object key, long clusterId, string clusterPath)
+        {
+
+            string left = GenerateHashedPath(clusterId);
+
+            string right = GenerateHashedPath(key);
+
+            string path = RepositoryRoot;
+
+            if (left.Length > 0)
+                path += left + "/";
+
+            if (clusterPath.Length > 0)
+                path += clusterPath + "/";
+
+            if (right.Length > 0)
+                path += right;
+
+            return path;
+
+        }
+
+
+        public string GetHashedPath(long id, string clusterPath)
         {
             return GetHashedPath(id, 0, clusterPath);
         }
 
         public string GetClusterHashedPath(long clusterId, string clusterPath)
-		{
-			return GetHashedPath(0, clusterId, clusterPath);
-		}
+        {
+            return GetHashedPath(0, clusterId, clusterPath);
+        }
 
 
 
 
-		public string GetHashedPath(string id, string clusterPath)
-		{
-			return GetHashedPath(id, 0, clusterPath);
-		}
+        public string GetHashedPath(string id, string clusterPath)
+        {
+            return GetHashedPath(id, 0, clusterPath);
+        }
 
 
 
-		public long GetNewStoreId(long clusterId, string clusterPath)
-		{
-			string clusterhashedPath = GetClusterHashedPath(clusterId, clusterPath);
-			long newStoreId=0;
-			
-			if(!dicClusters.ContainsKey(clusterId))
-				dicClusters.TryAdd(clusterId, new ConcurrentDictionary<string, StoreId>());
-			
-			if(!dicClusters[clusterId].ContainsKey(clusterPath))
-				dicClusters[clusterId][clusterPath]= new StoreId(this, clusterhashedPath);
-			
-			newStoreId = dicClusters[clusterId][clusterPath].GetNewId();
+        public long GetNewStoreId(long clusterId, string clusterPath)
+        {
+            string clusterhashedPath = GetClusterHashedPath(clusterId, clusterPath);
+            long newStoreId = 0;
 
-			return newStoreId;
-		}
+            if (!dicClusters.ContainsKey(clusterId))
+                dicClusters.TryAdd(clusterId, new ConcurrentDictionary<string, StoreId>());
+
+            if (!dicClusters[clusterId].ContainsKey(clusterPath))
+                dicClusters[clusterId][clusterPath] = new StoreId(this, clusterhashedPath);
+
+            newStoreId = dicClusters[clusterId][clusterPath].GetNewId();
+
+            return newStoreId;
+        }
         public long GetNewStoreId(string clusterPath = "")
         {
             return GetNewStoreId(0, clusterPath);
         }
 
-        public string [] GetDirs(string hashingPath, bool justGFS=true)
-		{
-			string [] dirs;
-			if(justGFS)
-			{
-				dirs= System.IO.Directory.GetDirectories(hashingPath, "$*");
-				for(int i=0; i<dirs.Length; i++)
-				{	
-					dirs[i] = dirs[i].Substring(
-				 		dirs[i].LastIndexOf("$"));
-					
-				}
-			}
-			else 
-				dirs= System.IO.Directory.GetDirectories(hashingPath);
-			
-			return dirs;
-		}
-		
-		public  string [] GetFiles(string hashingPath, bool justGFS=true)
-		{
-			string [] files;
-			if(justGFS)
-			{
-				files= System.IO.Directory.GetFiles(hashingPath, "$*");
-				for(int i=0; i<files.Length; i++)
-				{	
-					files[i] = files[i].Substring(
-				 		files[i].LastIndexOf("$"));
-					
-				}
-			}
-			else 
-				files= System.IO.Directory.GetFiles(hashingPath);
-			
-			return files;
-			
-		}
+        public string[] GetDirs(string hashingPath, bool justGFS = true)
+        {
+            string[] dirs;
+            if (justGFS)
+            {
+                dirs = System.IO.Directory.GetDirectories(hashingPath, "$*");
+                for (int i = 0; i < dirs.Length; i++)
+                {
+                    dirs[i] = dirs[i].Substring(
+                         dirs[i].LastIndexOf("$"));
+
+                }
+            }
+            else
+                dirs = System.IO.Directory.GetDirectories(hashingPath);
+
+            return dirs;
+        }
+
+        public string[] GetFiles(string hashingPath, bool justGFS = true)
+        {
+            string[] files;
+            if (justGFS)
+            {
+                files = System.IO.Directory.GetFiles(hashingPath, "$*");
+                for (int i = 0; i < files.Length; i++)
+                {
+                    files[i] = files[i].Substring(
+                         files[i].LastIndexOf("$"));
+
+                }
+            }
+            else
+                files = System.IO.Directory.GetFiles(hashingPath);
+
+            return files;
+
+        }
         public string[] GetFilesStartByTerm(string hashingPath, string startByTerm)
         {
             string[] files;
-   
-            files = Directory.GetFiles(hashingPath, startByTerm+"*");
-            
-           
+
+            files = Directory.GetFiles(hashingPath, startByTerm + "*");
+
+
 
             return files;
 
         }
         public void GetBytes(Stream stream, byte[] bytesInStream)
-		{
-			//byte[] bytesInStream = new byte[stream.Length];
-		        stream.Read(bytesInStream, 0, (int)bytesInStream.Length);
-			
-			
-		}
-		
-		public byte[] GetBytes(Stream stream)
-		{
-			stream.Seek(0, SeekOrigin.Begin);
-			byte[] bytesInStream = new byte[stream.Length];
-		        stream.Read(bytesInStream, 0, (int)bytesInStream.Length);
-			
-			return bytesInStream;
-		}
-		
-		public void SaveStreamToFile(string fileFullPath, Stream stream, bool compress)
-		{
-			// Create the compressed file.
+        {
+            //byte[] bytesInStream = new byte[stream.Length];
+            stream.Read(bytesInStream, 0, (int)bytesInStream.Length);
+        }
+
+        public byte[] GetBytes(Stream stream)
+        {
+            stream.Seek(0, SeekOrigin.Begin);
+            byte[] bytesInStream = new byte[stream.Length];
+            stream.Read(bytesInStream, 0, (int)bytesInStream.Length);
+
+            return bytesInStream;
+        }
+
+        public void SaveStreamToFile(string fileFullPath, Stream stream, bool compress)
+        {
+            // Create the compressed file.
             using (FileStream outFile = File.Create(fileFullPath))
-			{
-				if(compress){
-					using (GZipStream Compress = 
-	                        	new GZipStream(outFile, 
-	                        	CompressionMode.Compress))                        				
-					{
-						// Copy the source file into 
-	                    // the compression stream.
-	                    stream.CopyTo(Compress);
-					}
-				}else{
-					stream.CopyTo(outFile);
-				}
-			}
-		}
-		
-		public Stream LoadStreamFromFile(string fileFullPath, bool decompress)
-		{
-			Stream content= System.IO.File.OpenRead(fileFullPath);
-			
-			// Compresstion
-			if(decompress)
-			{	
-				var deccontent = new GZipStream(content, CompressionMode.Decompress, false);
-				
-				MemoryStream ms=new MemoryStream();	
-				
-				deccontent.CopyTo(ms);
-				long ln = ms.Length;
-				deccontent.Close();
-				return ms;
-			}
-			
-			return content;
-		}
-		
-		
-		public void SaveStreamToFileOld(string fileFullPath, Stream stream, bool compress)
-		{
-		
-		    //if (stream.Length == 0) return;
-		
-		    // Create a FileStream object to write a stream to a file
-		    using (FileStream fileStream = System.IO.File.Create(fileFullPath))
-		    {
-				stream.CopyTo(fileStream);
-				/*
+            {
+                if (compress)
+                {
+                    using (GZipStream Compress =
+                                new GZipStream(outFile,
+                                CompressionMode.Compress))
+                    {
+                        // Copy the source file into 
+                        // the compression stream.
+                        stream.CopyTo(Compress);
+                    }
+                }
+                else
+                {
+                    stream.CopyTo(outFile);
+                }
+            }
+        }
+
+        public async Task SaveStreamToFileAsync(string fileFullPath, Stream stream, bool doCompress)
+        {
+            // Create the compressed file.
+            using (FileStream outFile = File.Create(fileFullPath))
+            {
+                if (doCompress)
+                {
+                    using (GZipStream compress =
+                                new GZipStream(outFile,
+                                CompressionMode.Compress))
+                    {
+                        await stream.CopyToAsync(compress);
+                    }
+                }
+                else
+                {
+                    await stream.CopyToAsync(outFile);
+                }
+            }
+        }
+
+        public Stream LoadStreamFromFile(string fileFullPath, bool decompress)
+        {
+            Stream content = System.IO.File.OpenRead(fileFullPath);
+
+            // Compresstion
+            if (decompress)
+            {
+                var deccontent = new GZipStream(content, CompressionMode.Decompress, false);
+
+                MemoryStream ms = new MemoryStream();
+
+                deccontent.CopyTo(ms);
+                deccontent.Close();
+
+                return ms;
+            }
+
+            return content;
+        }
+
+        public async Task<Stream> LoadStreamFromFileAsync(string fileFullPath, bool decompress)
+        {
+            Stream content = File.OpenRead(fileFullPath);
+
+            // Compresstion
+            if (decompress)
+            {
+                var deccontent = new GZipStream(content, CompressionMode.Decompress, false);
+
+                MemoryStream ms = new MemoryStream();
+
+                await deccontent.CopyToAsync(ms);
+                deccontent.Close();
+
+                return ms;
+            }
+
+            return content;
+        }
+
+        public void SaveStreamToFileOld(string fileFullPath, Stream stream, bool compress)
+        {
+            //if (stream.Length == 0) return;
+
+            // Create a FileStream object to write a stream to a file
+            using (FileStream fileStream = System.IO.File.Create(fileFullPath))
+            {
+                stream.CopyTo(fileStream);
+                /*
 				if(stream.Length!=0){
 					
 					
@@ -308,65 +351,66 @@ namespace Acrobit.AcroFS
 		        // Use FileStream object to write to the specified file
 		        fileStream.Write(bytesInStream, 0, bytesInStream.Length);
 				}*/
-				
-		    }
-		}
-		
-		public void SaveStringToFile(string fileFullPath, string content)
-		{
-		    //if (stream.Length == 0) return;
-		
-		    // Create a FileStream object to write a stream to a file
-		    using (FileStream fileStream = System.IO.File.Create(fileFullPath))
-		    {
-				if(content.Length!=0){				
-					
-					using(StreamWriter sw=new StreamWriter(fileStream))
-						sw.Write(content);				
-					
-				}
-		    }
-		}
-		
-		public void PrepaireDirectoryByFilename(string filename)
-		{
 
-			
-			var index = filename.LastIndexOf('/');
+            }
+        }
+
+        public void SaveStringToFile(string fileFullPath, string content)
+        {
+            //if (stream.Length == 0) return;
+
+            // Create a FileStream object to write a stream to a file
+            using (FileStream fileStream = System.IO.File.Create(fileFullPath))
+            {
+                if (content.Length != 0)
+                {
+
+                    using (StreamWriter sw = new StreamWriter(fileStream))
+                        sw.Write(content);
+
+                }
+            }
+        }
+
+        public void PrepaireDirectoryByFilename(string filename)
+        {
+
+
+            var index = filename.LastIndexOf('/');
             if (index < 0) return;
 
-            string folderPath = filename.Substring(0, index+1);
+            string folderPath = filename.Substring(0, index + 1);
 
-			
 
-			System.IO.Directory.CreateDirectory(folderPath);
-		}
 
-		#region Options
-		public Core UseSimplePath(bool useSimplePath = true)
-		{
-			_config.UseSimplePath = useSimplePath;
-			return this;
-		}
-		public Core Root(string repositoryRoot)
-		{
-			if (string.IsNullOrEmpty(repositoryRoot))
-				repositoryRoot = GetDefaultRepositoryPath();
+            System.IO.Directory.CreateDirectory(folderPath);
+        }
 
-			if (repositoryRoot.Last() != '/')
-				repositoryRoot += '/';
+        #region Options
+        public Core UseSimplePath(bool useSimplePath = true)
+        {
+            _config.UseSimplePath = useSimplePath;
+            return this;
+        }
+        public Core Root(string repositoryRoot)
+        {
+            if (string.IsNullOrEmpty(repositoryRoot))
+                repositoryRoot = GetDefaultRepositoryPath();
+
+            if (repositoryRoot.Last() != '/')
+                repositoryRoot += '/';
 
 
             if (!Directory.Exists(repositoryRoot))
-				Directory.CreateDirectory(repositoryRoot);
-			_repositoryRoot = repositoryRoot;
+                Directory.CreateDirectory(repositoryRoot);
+            _repositoryRoot = repositoryRoot;
 
 
-			return this;
+            return this;
 
-		}
-		#endregion
+        }
+        #endregion
 
-	}
+    }
 }
 

--- a/Acrobit.AcroFS/Core.cs
+++ b/Acrobit.AcroFS/Core.cs
@@ -1,8 +1,6 @@
 using System;
-using System.IO;
-using System.Collections;
-using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,7 +10,6 @@ namespace Acrobit.AcroFS
 {
     public class Core
     {
-
         public StoreConfig _config;
         string _repositoryRoot;
 
@@ -98,13 +95,11 @@ namespace Acrobit.AcroFS
             return hashed;
         }
 
-
         public ConcurrentDictionary<long, ConcurrentDictionary<string, StoreId>> dicClusters =
             new ConcurrentDictionary<long, ConcurrentDictionary<string, StoreId>>();
 
         public string GetHashedPath(object key, long clusterId, string clusterPath)
         {
-
             string left = GenerateHashedPath(clusterId);
 
             string right = GenerateHashedPath(key);
@@ -121,9 +116,7 @@ namespace Acrobit.AcroFS
                 path += right;
 
             return path;
-
         }
-
 
         public string GetHashedPath(long id, string clusterPath)
         {

--- a/Acrobit.AcroFS/Core.cs
+++ b/Acrobit.AcroFS/Core.cs
@@ -20,7 +20,6 @@ namespace Acrobit.AcroFS
         {
             get
             {
-
                 return _repositoryRoot;
             }
         }
@@ -33,33 +32,17 @@ namespace Acrobit.AcroFS
                 "default-store/"
                 );
 
-
-
-
             return defaultPath;
-
         }
 
-        //public Core(StoreConfig config=null)
-        //{
-        //	var repositoryRoot = GetDefaultRepositoryPath();
-        //	if (!Directory.Exists(repositoryRoot))
-        //		Directory.CreateDirectory(repositoryRoot);
-
-        //	_repositoryRoot = repositoryRoot;
-        //          _config = config;
-        //      }
-
-        public Core(string repositoryRoot = null, StoreConfig config = null)
+        public Core(string? repositoryRoot = null, StoreConfig? config = null)
         {
             _config = config ?? new StoreConfig
             {
                 UseSimplePath = false,
-
             };
 
-            Root(repositoryRoot);
-
+            _repositoryRoot = Root(repositoryRoot);
         }
 
         public string GenerateHashedPath(object key)
@@ -68,10 +51,9 @@ namespace Acrobit.AcroFS
                 return GenerateHashedPath((string)key);
             if (key.GetType() == typeof(int))
                 return GenerateHashedPath((int)key);
-            else return GenerateHashedPath((long)key);
-
+            else
+                return GenerateHashedPath((long)key);
         }
-
 
         public string GenerateHashedPath(long val)
         {
@@ -153,20 +135,14 @@ namespace Acrobit.AcroFS
             return GetHashedPath(0, clusterId, clusterPath);
         }
 
-
-
-
         public string GetHashedPath(string id, string clusterPath)
         {
             return GetHashedPath(id, 0, clusterPath);
         }
 
-
-
         public long GetNewStoreId(long clusterId, string clusterPath)
         {
             string clusterhashedPath = GetClusterHashedPath(clusterId, clusterPath);
-            long newStoreId = 0;
 
             if (!dicClusters.ContainsKey(clusterId))
                 dicClusters.TryAdd(clusterId, new ConcurrentDictionary<string, StoreId>());
@@ -174,10 +150,10 @@ namespace Acrobit.AcroFS
             if (!dicClusters[clusterId].ContainsKey(clusterPath))
                 dicClusters[clusterId][clusterPath] = new StoreId(this, clusterhashedPath);
 
-            newStoreId = dicClusters[clusterId][clusterPath].GetNewId();
-
+            long newStoreId = dicClusters[clusterId][clusterPath].GetNewId();
             return newStoreId;
         }
+
         public long GetNewStoreId(string clusterPath = "")
         {
             return GetNewStoreId(0, clusterPath);
@@ -188,7 +164,7 @@ namespace Acrobit.AcroFS
             string[] dirs;
             if (justGFS)
             {
-                dirs = System.IO.Directory.GetDirectories(hashingPath, "$*");
+                dirs = Directory.GetDirectories(hashingPath, "$*");
                 for (int i = 0; i < dirs.Length; i++)
                 {
                     dirs[i] = dirs[i].Substring(
@@ -207,7 +183,7 @@ namespace Acrobit.AcroFS
             string[] files;
             if (justGFS)
             {
-                files = System.IO.Directory.GetFiles(hashingPath, "$*");
+                files = Directory.GetFiles(hashingPath, "$*");
                 for (int i = 0; i < files.Length; i++)
                 {
                     files[i] = files[i].Substring(
@@ -216,25 +192,18 @@ namespace Acrobit.AcroFS
                 }
             }
             else
-                files = System.IO.Directory.GetFiles(hashingPath);
+                files = Directory.GetFiles(hashingPath);
 
             return files;
-
         }
+
         public string[] GetFilesStartByTerm(string hashingPath, string startByTerm)
         {
-            string[] files;
-
-            files = Directory.GetFiles(hashingPath, startByTerm + "*");
-
-
-
-            return files;
-
+            return Directory.GetFiles(hashingPath, startByTerm + "*");
         }
+
         public void GetBytes(Stream stream, byte[] bytesInStream)
         {
-            //byte[] bytesInStream = new byte[stream.Length];
             stream.Read(bytesInStream, 0, (int)bytesInStream.Length);
         }
 
@@ -331,59 +300,26 @@ namespace Acrobit.AcroFS
             return content;
         }
 
-        public void SaveStreamToFileOld(string fileFullPath, Stream stream, bool compress)
-        {
-            //if (stream.Length == 0) return;
-
-            // Create a FileStream object to write a stream to a file
-            using (FileStream fileStream = System.IO.File.Create(fileFullPath))
-            {
-                stream.CopyTo(fileStream);
-                /*
-				if(stream.Length!=0){
-					
-					
-					
-		        // Fill the bytes[] array with the stream data
-		        byte[] bytesInStream = new byte[stream.Length];
-		        stream.Read(bytesInStream, 0, (int)bytesInStream.Length);
-		
-		        // Use FileStream object to write to the specified file
-		        fileStream.Write(bytesInStream, 0, bytesInStream.Length);
-				}*/
-
-            }
-        }
-
         public void SaveStringToFile(string fileFullPath, string content)
         {
-            //if (stream.Length == 0) return;
-
             // Create a FileStream object to write a stream to a file
-            using (FileStream fileStream = System.IO.File.Create(fileFullPath))
+            using FileStream fileStream = File.Create(fileFullPath);
+
+            if (content.Length != 0)
             {
-                if (content.Length != 0)
-                {
-
-                    using (StreamWriter sw = new StreamWriter(fileStream))
-                        sw.Write(content);
-
-                }
+                using (StreamWriter sw = new StreamWriter(fileStream))
+                    sw.Write(content);
             }
         }
 
         public void PrepaireDirectoryByFilename(string filename)
         {
-
-
             var index = filename.LastIndexOf('/');
             if (index < 0) return;
 
             string folderPath = filename.Substring(0, index + 1);
 
-
-
-            System.IO.Directory.CreateDirectory(folderPath);
+            Directory.CreateDirectory(folderPath);
         }
 
         #region Options
@@ -392,7 +328,8 @@ namespace Acrobit.AcroFS
             _config.UseSimplePath = useSimplePath;
             return this;
         }
-        public Core Root(string repositoryRoot)
+
+        public string Root(string? repositoryRoot)
         {
             if (string.IsNullOrEmpty(repositoryRoot))
                 repositoryRoot = GetDefaultRepositoryPath();
@@ -400,15 +337,14 @@ namespace Acrobit.AcroFS
             if (repositoryRoot.Last() != '/')
                 repositoryRoot += '/';
 
-
             if (!Directory.Exists(repositoryRoot))
                 Directory.CreateDirectory(repositoryRoot);
+
             _repositoryRoot = repositoryRoot;
 
-
-            return this;
-
+            return _repositoryRoot;
         }
+
         #endregion
 
     }

--- a/Acrobit.AcroFS/Extensions/StringExtensions.cs
+++ b/Acrobit.AcroFS/Extensions/StringExtensions.cs
@@ -1,37 +1,50 @@
 using System;
 using System.Text;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Acrobit.AcroFS
 {
 
-	public static class StringExtensions
+    public static class StringExtensions
 
-	{
-		public static MemoryStream ToMemoryStream(this string source) {
-			return source.ToMemoryStream(ASCIIEncoding.UTF8);
-		}
+    {
+        public static MemoryStream ToMemoryStream(this string source)
+        {
+            return source.ToMemoryStream(ASCIIEncoding.UTF8);
+        }
 
+        public static MemoryStream ToMemoryStream(this string source, Encoding encoding)
+        {
+            return new MemoryStream(encoding.GetBytes(source));
+        }
 
-		public static MemoryStream ToMemoryStream(this string source, Encoding encoding)		
-		{
-			return new MemoryStream(encoding.GetBytes(source));		
-		}
-		
-		public static string ToUtf8String(this Stream stream) {
-			
-			
-			byte[] buffer=new byte[stream.Length];
-			stream.Seek(0,SeekOrigin.Begin);
-			
-			stream.Read(buffer, 0, buffer.Length);
-			
-			
-			Encoding ae = Encoding.GetEncoding("utf-8");
-			string result = ae.GetString(buffer);
+        public static string ToUtf8String(this Stream stream)
+        {
+            byte[] buffer = new byte[stream.Length];
+            stream.Seek(0, SeekOrigin.Begin);
 
-			return result;
-		}
+            stream.Read(buffer, 0, buffer.Length);
+
+            Encoding ae = Encoding.GetEncoding("utf-8");
+            string result = ae.GetString(buffer);
+
+            return result;
+        }
+
+        public static async Task<string> ToUtf8StringAsync(this Stream stream)
+        {
+            byte[] buffer = new byte[stream.Length];
+            stream.Seek(0, SeekOrigin.Begin);
+
+            await stream.ReadAsync(buffer, 0, buffer.Length);
+
+            Encoding ae = Encoding.GetEncoding("utf-8");
+            string result = ae.GetString(buffer);
+
+            return result;
+        }
+
         public static string ReadToEnd(this Stream stream)
         {
             stream.Seek(0, SeekOrigin.Begin);
@@ -39,7 +52,6 @@ namespace Acrobit.AcroFS
             var reader = new StreamReader(stream);
             return reader.ReadToEnd();
         }
-
     }
 }
 

--- a/Acrobit.AcroFS/Extensions/StringExtensions.cs
+++ b/Acrobit.AcroFS/Extensions/StringExtensions.cs
@@ -1,6 +1,5 @@
-using System;
-using System.Text;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Acrobit.AcroFS

--- a/Acrobit.AcroFS/FileStore.cs
+++ b/Acrobit.AcroFS/FileStore.cs
@@ -16,20 +16,21 @@ namespace Acrobit.AcroFS
     public class FileStore
     {
         static Dictionary<string, FileStore> stores = new Dictionary<string, FileStore>();
-        private Core _core = null;
+        private readonly Core _core;
 
-        public static FileStore CreateStore(string repositoryRoot = null, StoreConfig config = null)
+        public static FileStore CreateStore(string? repositoryRoot = null, StoreConfig? config = null)
         {
-            if (string.IsNullOrEmpty(repositoryRoot))
-                repositoryRoot = Core.GetDefaultRepositoryPath();
+            string root = repositoryRoot ?? Core.GetDefaultRepositoryPath();
 
-            if (repositoryRoot != null && stores.ContainsKey(repositoryRoot))
-                return stores[repositoryRoot];
+            if (stores.ContainsKey(root))
+            {
+                return stores[root];
+            }
 
-            var core = new Core(repositoryRoot, config);
+            var core = new Core(root, config);
             var filestore = new FileStore(core);
 
-            stores[repositoryRoot] = filestore;
+            stores[root] = filestore;
 
             return filestore;
         }

--- a/Acrobit.AcroFS/FileStore.cs
+++ b/Acrobit.AcroFS/FileStore.cs
@@ -547,6 +547,7 @@ namespace Acrobit.AcroFS
             _core.UseSimplePath(useSimplePath);
             return this;
         }
+
         public FileStore Root(string repositoryRoot)
         {
             _core.Root(repositoryRoot);

--- a/Acrobit.AcroFS/FileStore.cs
+++ b/Acrobit.AcroFS/FileStore.cs
@@ -5,287 +5,377 @@ using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.IO.Compression;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 // Gita FileSystem Storage
 namespace Acrobit.AcroFS
 {
-	/// <summary>
-	/// Storing and retriving files as gita hashed structured file system 
-	/// </summary>
-	public  class FileStore
-	{
-        static Dictionary<string , FileStore> stores = new Dictionary<string, FileStore>();
-
+    /// <summary>
+    /// Storing and retriving files as gita hashed structured file system 
+    /// </summary>
+    public class FileStore
+    {
+        static Dictionary<string, FileStore> stores = new Dictionary<string, FileStore>();
         private Core _core = null;
-        public  static FileStore CreateStore(string repositoryRoot = null, StoreConfig config = null)
-        {
-			if (string.IsNullOrEmpty(repositoryRoot))
-				repositoryRoot = Core.GetDefaultRepositoryPath();
 
-			if (repositoryRoot!=null && stores.ContainsKey(repositoryRoot))
+        public static FileStore CreateStore(string repositoryRoot = null, StoreConfig config = null)
+        {
+            if (string.IsNullOrEmpty(repositoryRoot))
+                repositoryRoot = Core.GetDefaultRepositoryPath();
+
+            if (repositoryRoot != null && stores.ContainsKey(repositoryRoot))
                 return stores[repositoryRoot];
 
             var core = new Core(repositoryRoot, config);
             var filestore = new FileStore(core);
-			
+
             stores[repositoryRoot] = filestore;
 
             return filestore;
-		}
+        }
 
-		[Obsolete("This method is obsolete. use CreateStore instead")]
-		public static FileStore GetStore(string repositoryRoot = null, StoreConfig config = null) => CreateStore(repositoryRoot, config);
+        [Obsolete("This method is obsolete. use CreateStore instead")]
+        public static FileStore GetStore(string repositoryRoot = null, StoreConfig config = null) => CreateStore(repositoryRoot, config);
 
+        public bool Exists(object docKey, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
+        {
+            string hashedPath = _core.GetHashedPath(docKey, clusterId, clusterPath);
+            return File.Exists(hashedPath);
+        }
 
-		//public static FileStore GetStore(StoreConfig config = null)
-		//{
-
-		//    if (stores.ContainsKey("default"))
-		//        return stores["default"];
-
-		//    var core = new Core(config);
-		//    var filestore = new FileStore(core);
-		//    stores["default"] = filestore;
-
-		//    return filestore;
-		//}
-
-
-		public bool Exists(object docKey, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
-		{
-			string hashedPath = _core.GetHashedPath(docKey, clusterId, clusterPath);
-			return File.Exists(hashedPath);
-		}
-	
-
-		public FileStore(Core core)
+        public FileStore(Core core)
         {
             _core = core;
         }
 
-		#region Save
+        #region Save
 
-		// Storing a binary content 
-		public long StoreStream(Stream content, string clusterPath = "", StoreOptions options = StoreOptions.None, long id = 0, long clusterId = 0)
+        // Storing a binary content 
+        public long StoreStream(Stream content, string clusterPath = "", StoreOptions options = StoreOptions.None, long id = 0, long clusterId = 0)
         {
-			// Checking content validation
-			if (content == null)
-				return 0;
+            // Checking content validation
+            if (content == null)
+                return 0;
 
-			// Generating Store Id if needed
-			long storeId = id;
-			if (storeId == 0)
-				storeId = _core.GetNewStoreId(clusterId, clusterPath);
+            // Generating Store Id if needed
+            long storeId = id;
+            if (storeId == 0)
+                storeId = _core.GetNewStoreId(clusterId, clusterPath);
 
-			// full path of the file
-			string hashedPath =
-				_core.GetHashedPath(storeId, clusterId, clusterPath);
+            // full path of the file
+            string hashedPath =
+                _core.GetHashedPath(storeId, clusterId, clusterPath);
 
-			// Creating top directories
-			_core.PrepaireDirectoryByFilename(hashedPath);
+            // Creating top directories
+            _core.PrepaireDirectoryByFilename(hashedPath);
 
-			// Saving stream to the file 
-			_core.SaveStreamToFile(hashedPath, content,
-								  options == StoreOptions.Compress);
+            // Saving stream to the file 
+            _core.SaveStreamToFile(hashedPath, content,
+                                  options == StoreOptions.Compress);
 
-			// Returns new store id
-			return storeId;
-		}
-		public void StoreStreamByKey(object key, Stream content,   string clusterPath="", StoreOptions options = StoreOptions.None, long clusterId=0)
-		{
-			// Checking content validation
-			if(content==null || key==null)
-				throw new Exception("Content or key not valid!");
+            // Returns new store id
+            return storeId;
+        }
 
-			// full path of the file
-			string hashedPath =
-				_core.GetHashedPath(key, clusterId, clusterPath);
-			
-			// Creating top directories
-			_core.PrepaireDirectoryByFilename(hashedPath);
-			
-			// Saving stream to the file 
-			_core.SaveStreamToFile(hashedPath, content, 
-			                      options== StoreOptions.Compress);
-			
-		}
-		
-		// Storing a utf8 text content 
-		public  long  StoreText(string content, string clusterPath="", StoreOptions options = StoreOptions.None, long id=0, long clusterId=0)
-		{	
-			// Converting utf8 text to Memory Stream
-			var stream = content.ToMemoryStream();
-			
-			// Storing to disk
-			var result = StoreStream(stream, clusterPath,options, id, clusterId);
-			
-			stream.Close();			
-			return result;
-		}
-		public void StoreTextByKey(object key, string content, string clusterPath = "", StoreOptions options = StoreOptions.None, long clusterId = 0)
-		{
-			if (content == null || key == null)
-				throw new Exception("Content or key not valid!");
-
-			// Converting utf8 text to Memory Stream
-			var stream = content.ToMemoryStream();
-
-			// Storing to disk
-			StoreStreamByKey(key, stream, clusterPath, options, clusterId);
-
-			stream.Close();
-		}
-
-		static bool IsSubclassOfRawGeneric(Type generic, Type toCheck)
-		{
-			while (toCheck != null && toCheck != typeof(object))
-			{
-				var cur = toCheck.IsGenericType ? toCheck.GetGenericTypeDefinition() : toCheck;
-				if (generic == cur)
-				{
-					return true;
-				}
-				toCheck = toCheck.BaseType;
-			}
-			return false;
-		}
-
-		public long Store<T>(T data, string clusterPath = "", StoreOptions options = StoreOptions.None, long id = 0, long clusterId = 0)
+        public void StoreStreamByKey(object key, Stream content, string clusterPath = "", StoreOptions options = StoreOptions.None, long clusterId = 0)
         {
-            if (IsSubclassOfRawGeneric(typeof(Stream), typeof(T) ) )
+            // Checking content validation
+            if (content == null || key == null)
+                throw new Exception("Content or key not valid!");
+
+            // full path of the file
+            string hashedPath =
+                _core.GetHashedPath(key, clusterId, clusterPath);
+
+            // Creating top directories
+            _core.PrepaireDirectoryByFilename(hashedPath);
+
+            // Saving stream to the file 
+            _core.SaveStreamToFile(hashedPath, content, options == StoreOptions.Compress);
+        }
+
+        public async Task StoreStreamByKeyAsync(object key, Stream content, string clusterPath = "", StoreOptions options = StoreOptions.None, long clusterId = 0)
+        {
+            // Checking content validation
+            if (content == null || key == null)
+                throw new Exception("Content or key not valid!");
+
+            // full path of the file
+            string hashedPath =
+                _core.GetHashedPath(key, clusterId, clusterPath);
+
+            // Creating top directories
+            _core.PrepaireDirectoryByFilename(hashedPath);
+
+            // Saving stream to the file 
+            await _core.SaveStreamToFileAsync(hashedPath, content, options == StoreOptions.Compress);
+        }
+
+        // Storing a utf8 text content 
+        public long StoreText(string content, string clusterPath = "", StoreOptions options = StoreOptions.None, long id = 0, long clusterId = 0)
+        {
+            // Converting utf8 text to Memory Stream
+            var stream = content.ToMemoryStream();
+
+            // Storing to disk
+            var result = StoreStream(stream, clusterPath, options, id, clusterId);
+
+            stream.Close();
+            return result;
+        }
+
+        public void StoreTextByKey(object key, string content, string clusterPath = "", StoreOptions options = StoreOptions.None, long clusterId = 0)
+        {
+            if (content == null || key == null)
+                throw new Exception("Content or key not valid!");
+
+            // Converting utf8 text to Memory Stream
+            var stream = content.ToMemoryStream();
+
+            // Storing to disk
+            StoreStreamByKey(key, stream, clusterPath, options, clusterId);
+
+            stream.Close();
+        }
+
+        public async Task StoreTextByKeyAsync(object key, string content, string clusterPath = "", StoreOptions options = StoreOptions.None, long clusterId = 0)
+        {
+            if (content == null || key == null)
+                throw new Exception("Content or key not valid!");
+
+            // Converting utf8 text to Memory Stream
+            var stream = content.ToMemoryStream();
+
+            // Storing to disk
+            await StoreStreamByKeyAsync(key, stream, clusterPath, options, clusterId);
+
+            stream.Close();
+        }
+
+        static bool IsSubclassOfRawGeneric(Type generic, Type toCheck)
+        {
+            while (toCheck != null && toCheck != typeof(object))
             {
-                return StoreStream(data as Stream, clusterPath, options, id, clusterId);
+                var cur = toCheck.IsGenericType ? toCheck.GetGenericTypeDefinition() : toCheck;
+                if (generic == cur)
+                {
+                    return true;
+                }
+
+                toCheck = toCheck.BaseType;
             }
-            else if (typeof(T) == typeof(string))
+            return false;
+        }
+
+        public long Store<T>(T data, string clusterPath = "", StoreOptions options = StoreOptions.None, long id = 0, long clusterId = 0)
+        {
+            if (data is Stream stream)
             {
-                return StoreText(data as string, clusterPath, options, id, clusterId);
+                return StoreStream(stream, clusterPath, options, id, clusterId);
+            }
+            else if (data is string s)
+            {
+                return StoreText(s, clusterPath, options, id, clusterId);
             }
 
             var jsonData = JsonConvert.SerializeObject(data);
             return StoreText(jsonData, clusterPath, options, id, clusterId);
         }
 
-		public void StoreByKey<T>(object key,T data,string clusterPath = "",  StoreOptions options = StoreOptions.None,  long clusterId = 0)
-		{
-			if (IsSubclassOfRawGeneric(typeof(Stream), typeof(T)))
-			{
-				StoreStreamByKey(key, data as Stream, clusterPath, options, clusterId);
-			}
-			else if (typeof(T) == typeof(string))
-			{
-				StoreTextByKey(key, data as string, clusterPath, options, clusterId);
+        public void StoreByKey<T>(object key, T data, string clusterPath = "", StoreOptions options = StoreOptions.None, long clusterId = 0)
+        {
+            if (data is Stream stream)
+            {
+                StoreStreamByKey(key, stream, clusterPath, options, clusterId);
+            }
+            else if (data is string s)
+            {
+                StoreTextByKey(key, s, clusterPath, options, clusterId);
+            }
 
-			}
+            var jsonData = JsonConvert.SerializeObject(data);
+            StoreTextByKey(key, jsonData, clusterPath, options, clusterId);
+        }
 
-			var jsonData = JsonConvert.SerializeObject(data);
-			StoreTextByKey(key, jsonData, clusterPath, options, clusterId);
-		}
+        public async Task StoreByKeyAsync<T>(object key, T data, string clusterPath = "", StoreOptions options = StoreOptions.None, long clusterId = 0)
+        {
+            if (data is Stream stream)
+            {
+                await StoreStreamByKeyAsync(key, stream, clusterPath, options, clusterId);
+            }
+            else if (data is string s)
+            {
+                await StoreTextByKeyAsync(key, s, clusterPath, options, clusterId);
+            }
 
+            var jsonData = JsonConvert.SerializeObject(data);
+            await StoreTextByKeyAsync(key, jsonData, clusterPath, options, clusterId);
+        }
 
-		// Attaching a binary content to a stored item 
-		public void AttachStream(object key, string attachName, Stream attachContent, string clusterPath="", StoreOptions options = StoreOptions.None, long clusterId=0)
-		{
-			// Checking content validation
-			if (attachContent == null)
-				throw new Exception("The attachment content is null");
-			
-			// full path of the file
-			string hashedPath = _core.GetHashedPath(key, clusterId, clusterPath);
-			
-			// Prepairing top directories
-			_core.PrepaireDirectoryByFilename(hashedPath);
-			
-			// Saving stream to the file 
-			_core.SaveStreamToFile(hashedPath+"-"+attachName, attachContent, options== StoreOptions.Compress);
-			
-		}
-		
-		// Attaching a text content to a stored item 
-		public  void AttachText(object key, string attachName, string attachContent, string clusterPath="",StoreOptions options = StoreOptions.None, long clusterId=0)
-		{
-			// Converting utf8 text to Memory Stream
-			var stream = attachContent.ToMemoryStream();
-			
-			// Store into disk
-			AttachStream(key, attachName, stream,clusterPath,options, clusterId);
-			
-			stream.Close();			
+        // Attaching a binary content to a stored item
+        public void AttachStream(object key, string attachName, Stream attachContent, string clusterPath = "", StoreOptions options = StoreOptions.None, long clusterId = 0)
+        {
+            // Checking content validation
+            if (attachContent == null)
+                throw new Exception("The attachment content is null");
 
-		}
+            // full path of the file
+            string hashedPath = _core.GetHashedPath(key, clusterId, clusterPath);
 
-		public void Attach<T>(object key, string attachName, T attachContent, string clusterPath = "", StoreOptions options = StoreOptions.None, long clusterId = 0)
-		{
-			if (IsSubclassOfRawGeneric(typeof(Stream), typeof(T)))
-			{
-				AttachStream(key, attachName, attachContent as Stream, clusterPath, options, clusterId);
+            // Prepairing top directories
+            _core.PrepaireDirectoryByFilename(hashedPath);
 
-			}
-			else if (typeof(T) == typeof(string))
-			{
-				AttachText(key, attachName, attachContent as string, clusterPath , options, clusterId);
-			}
+            // Saving stream to the file 
+            _core.SaveStreamToFile(hashedPath + "-" + attachName, attachContent, options == StoreOptions.Compress);
+        }
 
+        public async Task AttachStreamAsync(object key, string attachName, Stream attachContent, string clusterPath = "", StoreOptions options = StoreOptions.None, long clusterId = 0)
+        {
+            // Checking content validation
+            if (attachContent == null)
+                throw new Exception("The attachment content is null");
 
-			var jsonData = JsonConvert.SerializeObject(attachContent);
-			AttachText(key, attachName, jsonData, clusterPath, options, clusterId);
+            // full path of the file
+            string hashedPath = _core.GetHashedPath(key, clusterId, clusterPath);
 
-		}
+            // Prepairing top directories
+            _core.PrepaireDirectoryByFilename(hashedPath);
 
+            // Saving stream to the file 
+            await _core.SaveStreamToFileAsync(hashedPath + "-" + attachName, attachContent, options == StoreOptions.Compress);
+        }
 
-		// Returns a new store id, may be needed for only attachments
-		public  long GetNewStoreId(string clusterPath="", long clusterId=0 )
-		{
-			return _core.GetNewStoreId(clusterId, clusterPath);
-		}
+        // Attaching a text content to a stored item 
+        public void AttachText(object key, string attachName, string attachContent, string clusterPath = "", StoreOptions options = StoreOptions.None, long clusterId = 0)
+        {
+            // Converting utf8 text to Memory Stream
+            var stream = attachContent.ToMemoryStream();
 
-		#endregion
+            // Store into disk
+            AttachStream(key, attachName, stream, clusterPath, options, clusterId);
 
+            stream.Close();
+        }
 
-		#region Load
+        public async Task AttachTextAsync(object key, string attachName, string attachContent, string clusterPath = "", StoreOptions options = StoreOptions.None, long clusterId = 0)
+        {
+            // Converting utf8 text to Memory Stream
+            var stream = attachContent.ToMemoryStream();
 
+            // Store into disk
+            await AttachStreamAsync(key, attachName, stream, clusterPath, options, clusterId);
 
-		// Loading a binary content 
-		public Stream Load(object docKey, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
-		{
-			string hashedPath = _core.GetHashedPath(docKey, clusterId, clusterPath);
+            stream.Close();
+        }
 
-			if (!File.Exists(hashedPath))
-				return null;
+        public void Attach<T>(object key, string attachName, T attachContent, string clusterPath = "", StoreOptions options = StoreOptions.None, long clusterId = 0)
+        {
+            if (attachContent is Stream stream)
+            {
+                AttachStream(key, attachName, stream, clusterPath, options, clusterId);
 
-			Stream content = _core.LoadStreamFromFile(hashedPath,
-						   options == LoadOptions.Decompress);
+            }
+            else if (attachContent is string s)
+            {
+                AttachText(key, attachName, s, clusterPath, options, clusterId);
+            }
 
-			return content;
-		}
+            var jsonData = JsonConvert.SerializeObject(attachContent);
+            AttachText(key, attachName, jsonData, clusterPath, options, clusterId);
+        }
 
+        public async Task AttachAsync<T>(object key, string attachName, T attachContent, string clusterPath = "", StoreOptions options = StoreOptions.None, long clusterId = 0)
+        {
+            if (attachContent is Stream stream)
+            {
+                await AttachStreamAsync(key, attachName, stream, clusterPath, options, clusterId);
+            }
+            else if (attachContent is string s)
+            {
+                await AttachTextAsync(key, attachName, s, clusterPath, options, clusterId);
+            }
 
-		// Loading a utf8 text content
-		public  string LoadTextUtf8(object docKey, string clusterPath="",LoadOptions options = LoadOptions.None, long clusterId=0)
-		{
-			var stream = Load(docKey,  clusterPath,  options, clusterId);
-			if(stream==null) return null;
-			
-			// Converting to utf8 text
-			string result = stream.ToUtf8String();
-			stream.Close();	
-			
-			return result;
-		}
+            var jsonData = JsonConvert.SerializeObject(attachContent);
+            await AttachTextAsync(key, attachName, jsonData, clusterPath, options, clusterId);
+        }
 
+        // Returns a new store id, may be needed for only attachments
+        public long GetNewStoreId(string clusterPath = "", long clusterId = 0)
+        {
+            return _core.GetNewStoreId(clusterId, clusterPath);
+        }
 
-		public T Load<T>(object docKey, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
-		{
-			var jsonData = LoadTextUtf8(docKey, clusterPath, options, clusterId);
-			return JsonConvert.DeserializeObject<T>(jsonData);
+        #endregion
 
-		}
+        #region Load
 
-		//public T Load<T>(long docKey, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
-  //      {
-		//	var jsonData = LoadTextUtf8(docKey, clusterPath, options, clusterId);
-		//	return JsonConvert.DeserializeObject<T>(jsonData);
+        // Loading a binary content 
+        public Stream Load(object docKey, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
+        {
+            string hashedPath = _core.GetHashedPath(docKey, clusterId, clusterPath);
 
-  //      }
+            if (!File.Exists(hashedPath))
+                return null;
+
+            Stream content = _core.LoadStreamFromFile(hashedPath, options == LoadOptions.Decompress);
+
+            return content;
+        }
+
+        public async Task<Stream> LoadAsync(object docKey, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
+        {
+            string hashedPath = _core.GetHashedPath(docKey, clusterId, clusterPath);
+
+            if (!File.Exists(hashedPath))
+                return null;
+
+            Stream content = await _core.LoadStreamFromFileAsync(hashedPath, options == LoadOptions.Decompress);
+
+            return content;
+        }
+
+        // Loading a utf8 text content
+        public string LoadTextUtf8(object docKey, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
+        {
+            var stream = Load(docKey, clusterPath, options, clusterId);
+            if (stream == null)
+            {
+                return null;
+            }
+
+            // Converting to utf8 text
+            string result = stream.ToUtf8String();
+            stream.Close();
+
+            return result;
+        }
+
+        public async Task<string> LoadTextUtf8Async(object docKey, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
+        {
+            var stream = await LoadAsync(docKey, clusterPath, options, clusterId);
+            if (stream == null)
+            {
+                return null;
+            }
+
+            // Converting to utf8 text
+            string result = await stream.ToUtf8StringAsync();
+            stream.Close();
+
+            return result;
+        }
+
+        public T Load<T>(object docKey, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
+        {
+            var jsonData = LoadTextUtf8(docKey, clusterPath, options, clusterId);
+            return JsonConvert.DeserializeObject<T>(jsonData);
+        }
+
+        public async Task<T> LoadAsync<T>(object docKey, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
+        {
+            var jsonData = await LoadTextUtf8Async(docKey, clusterPath, options, clusterId);
+            return JsonConvert.DeserializeObject<T>(jsonData);
+        }
 
         public string LoadText(object docKey, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
         {
@@ -297,23 +387,25 @@ namespace Acrobit.AcroFS
 
             return result;
         }
-            // Loading a binary attached item 
-        public  Stream LoadStreamAttachment(object key, string attachName, string clusterPath="", LoadOptions options = LoadOptions.None, long clusterId=0)
-		{
-			// Optaining pathes
-			string hashedPath = _core.GetHashedPath(key, clusterId, clusterPath);
-			string fullPath = hashedPath+"-"+attachName;
-			
-			// Checking for existing 
-			if(!File.Exists(fullPath))
-			   return null;
-			
-			// Load file from disk
-			Stream content= _core.LoadStreamFromFile(fullPath, 
-			               options == LoadOptions.Decompress);
-			
-			return content;
-		}
+
+        // Loading a binary attached item 
+        public Stream LoadStreamAttachment(object key, string attachName, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
+        {
+            // Optaining pathes
+            string hashedPath = _core.GetHashedPath(key, clusterId, clusterPath);
+            string fullPath = hashedPath + "-" + attachName;
+
+            // Checking for existing 
+            if (!File.Exists(fullPath))
+                return null;
+
+            // Load file from disk
+            Stream content = _core.LoadStreamFromFile(fullPath,
+                           options == LoadOptions.Decompress);
+
+            return content;
+        }
+
         public List<Stream> LoadStreamAttachments(object key, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
         {
             // Optaining pathes
@@ -332,40 +424,38 @@ namespace Acrobit.AcroFS
                            options == LoadOptions.Decompress));
             }
 
-
-
             return contents;
         }
 
-
-		public List<string> LoadTextAttachments(object docKey, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
+        public List<string> LoadTextAttachments(object docKey, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
         {
             var list = new List<string>();
 
             var streamList = LoadStreamAttachments(docKey, clusterPath, options, clusterId);
-         
-            foreach(var stream in streamList)
+
+            foreach (var stream in streamList)
             {
                 list.Add(stream.ReadToEnd());
                 stream.Close();
             }
             // Converting to utf8 text
-       
+
             return list;
 
         }
-        public  string LoadTextAttachment(object docKey, string attachName, string clusterPath="", LoadOptions options = LoadOptions.None,long clusterId=0)
-		{
-			var stream = LoadStreamAttachment(docKey,  attachName,  clusterPath,options,  clusterId);
-			if(stream==null) return null;
+
+        public string LoadTextAttachment(object docKey, string attachName, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
+        {
+            var stream = LoadStreamAttachment(docKey, attachName, clusterPath, options, clusterId);
+            if (stream == null) return null;
 
             // Converting to utf8 text
             string result = stream.ReadToEnd();
             stream.Close();
-			
-			return result;
-			
-		}
+
+            return result;
+
+        }
 
         // Loading a utf8 text attached item 
         public string LoadTextAttachmentUtf8(object docKey, string attachName, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
@@ -380,101 +470,91 @@ namespace Acrobit.AcroFS
             return result;
 
         }
-	
-		public T LoadAttachment<T>(object docKey, string attachName, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
-		{
-			var jsonData = LoadTextAttachmentUtf8(docKey, attachName, clusterPath, options, clusterId);
 
-			if (jsonData == null) return default(T);
+        public T LoadAttachment<T>(object docKey, string attachName, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
+        {
+            var jsonData = LoadTextAttachmentUtf8(docKey, attachName, clusterPath, options, clusterId);
 
-			return JsonConvert.DeserializeObject<T>(jsonData);
+            if (jsonData == null) return default(T);
 
-		}
+            return JsonConvert.DeserializeObject<T>(jsonData);
 
-		
+        }
 
 
-		public IList<T> LoadAttachments<T>(object docKey, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
-		{
-			var list = new List<T>();
+        public IList<T> LoadAttachments<T>(object docKey, string clusterPath = "", LoadOptions options = LoadOptions.None, long clusterId = 0)
+        {
+            var list = new List<T>();
 
-			var jsonList = LoadTextAttachments(docKey, clusterPath, options, clusterId);
+            var jsonList = LoadTextAttachments(docKey, clusterPath, options, clusterId);
 
-			foreach (var jsonData in jsonList)
-			{
-				list.Add(JsonConvert.DeserializeObject<T>(jsonData));
-			}
+            foreach (var jsonData in jsonList)
+            {
+                list.Add(JsonConvert.DeserializeObject<T>(jsonData));
+            }
 
-			return list;
+            return list;
+        }
 
-		}
+        #endregion
 
-		#endregion
+        #region Remove
 
-		#region Remove
+        // Loading a binary content 
+        public void Remove(object key, string clusterPath = "", long clusterId = 0)
+        {
 
-		// Loading a binary content 
-		public void Remove(object key, string clusterPath="", long clusterId=0)
-		{
-			
-			// Optaining pathes
-			string hashedPath = _core.GetHashedPath(key, clusterId, clusterPath);
-			
-			// Chekcking for existing 
-			if(!System.IO.File.Exists(hashedPath))
-			   return;
-			
-			// Removing the file
-			System.IO.File.Delete(hashedPath);
-			
-		}
-		
-		 int ccc=0;
-		// Loading a binary attached item 
-		public  void RemoveAttachment(object key, string attachName, string clusterPath="", long clusterId=0)
-		{
-		
-		
-			
-			// Optaining pathes
-			string hashedPath = _core.GetHashedPath(key, clusterId, clusterPath);
-			string fullPath = hashedPath+"-"+attachName;
-			
-		
-			
-			// Checking for existing 
-			if(!File.Exists(fullPath))
-			   return;
-			
-			
-			// Removing the file
-			try{
-				File.Delete(fullPath);	
-			}
-			catch{
-				
-			}
-			
-			//ccc++;
-		
-		}
+            // Optaining pathes
+            string hashedPath = _core.GetHashedPath(key, clusterId, clusterPath);
 
-		#endregion
+            // Chekcking for existing 
+            if (!System.IO.File.Exists(hashedPath))
+                return;
 
+            // Removing the file
+            System.IO.File.Delete(hashedPath);
 
-		#region Options
-		public FileStore UseSimplePath(bool useSimplePath = true)
-		{
-			_core.UseSimplePath(useSimplePath);
-			return this;
-		}
-		public FileStore Root(string repositoryRoot)
-		{
-			_core.Root(repositoryRoot);
-			return this;
-		}
-		#endregion
-	}
+        }
+
+        // Loading a binary attached item 
+        public void RemoveAttachment(object key, string attachName, string clusterPath = "", long clusterId = 0)
+        {
+            // Optaining pathes
+            string hashedPath = _core.GetHashedPath(key, clusterId, clusterPath);
+            string fullPath = hashedPath + "-" + attachName;
+
+            // Checking for existing 
+            if (!File.Exists(fullPath))
+                return;
+
+            // Removing the file
+            try
+            {
+                File.Delete(fullPath);
+            }
+            catch
+            {
+
+            }
+        }
+
+        #endregion
+
+        #region Options
+
+        public FileStore UseSimplePath(bool useSimplePath = true)
+        {
+            _core.UseSimplePath(useSimplePath);
+            return this;
+        }
+        public FileStore Root(string repositoryRoot)
+        {
+            _core.Root(repositoryRoot);
+            return this;
+        }
+
+        #endregion
+    }
 
     // Future options :
     // Load by gfs path : /clusterId/clusterPath/fileid/attachName/options

--- a/Acrobit.AcroFS/StoreId.cs
+++ b/Acrobit.AcroFS/StoreId.cs
@@ -3,66 +3,63 @@ using System.Linq;
 
 namespace Acrobit.AcroFS
 {
-	public class StoreId
-	{
-		string _clusterhashedPath;
-        Core _core = null;
+    public class StoreId
+    {
+        private readonly string _clusterhashedPath;
+        private readonly Core _core;
 
         public StoreId(Core core, string clusterhashedPath)
-		{
+        {
             _core = core;
             _clusterhashedPath = clusterhashedPath;
-		}
-		
-		long _storeId=0;
-		
-		public long GetNewId()
-		{
-			long newId;
-			
-			if(_storeId==0)
-			{
-				lock(this)
-				{
-					// chech again
-					if(_storeId==0) 
-					{
-						// _storeId = Core.FindNewIdFromFS(_clusterhashedPath);						
-						_storeId = LoadMaxId();
-					}
-				}
-				
-			}
-			
-			newId = System.Threading.Interlocked.Increment( ref _storeId);
-			return newId;
-			
-		}
-		
-		
-		public long LoadMaxId(string root="/")
-		{try{
-			string []dirs = _core.GetDirs(_clusterhashedPath+root);
-			if(dirs.Length==0)
-			{
-				string[] files= _core.GetFiles(_clusterhashedPath+root);
-				
-				string max=files.Length==0?"00":files.Max().Substring(1,2);
-				
-				root+= max;
-				root=root.Replace("/","").Replace("$","");
-				return Convert.ToInt64(root, 16);
-				
-			}
-		
-			return LoadMaxId(root+dirs.Max()+"/");
-			
-			}
-			catch{
-				return 0;
-			}
-				
-		}
-	}
+        }
+
+        long _storeId = 0;
+
+        public long GetNewId()
+        {
+            long newId;
+
+            if (_storeId == 0)
+            {
+                lock (this)
+                {
+                    // chech again
+                    if (_storeId == 0)
+                    {
+                        // _storeId = Core.FindNewIdFromFS(_clusterhashedPath);						
+                        _storeId = LoadMaxId();
+                    }
+                }
+            }
+
+            newId = System.Threading.Interlocked.Increment(ref _storeId);
+            return newId;
+        }
+
+        private long LoadMaxId(string root = "/")
+        {
+            try
+            {
+                string[] dirs = _core.GetDirs(_clusterhashedPath + root);
+                if (dirs.Length == 0)
+                {
+                    string[] files = _core.GetFiles(_clusterhashedPath + root);
+
+                    string max = files.Length == 0 ? "00" : files.Max().Substring(1, 2);
+
+                    root += max;
+                    root = root.Replace("/", "").Replace("$", "");
+                    return Convert.ToInt64(root, 16);
+                }
+
+                return LoadMaxId(root + dirs.Max() + "/");
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
Almost all methods related to getting or storing files now have async versions.  I did not add unit tests for the new async methods, though.  Maybe I should have?

I also went through the code and got rid of all warnings related to nullable.  Note that I added C# 11 to get some of the new language features for nullable generic return types, i.e. `T? MyMethod<T>()`.  So I added this to the csproj file:
```xml
<LangVersion>11.0</LangVersion>
```

Finally, I cleaned the code up here and there for consistency, including line breaks and whitespace.  I also removed a few unused methods.

Thanks.
